### PR TITLE
Non-root Makefiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,14 @@ jobs:
       - name: Install Neovim
         shell: bash
         run: |
-            wget -q https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.deb -O /tmp/nvim.deb
-            sudo dpkg -i /tmp/nvim.deb
+          test -d _neovim || {
+            mkdir -p _neovim
+            curl -sL "https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+          }
       - name: Run Tests
         run: |
+          export PATH="${PWD}/_neovim/bin:${PATH}"
+          export VIM="${PWD}/_neovim/share/nvim/runtime"
           nvim --version
           [ ! -d tests ] && exit 0
           make test

--- a/lua/makemapper/init.lua
+++ b/lua/makemapper/init.lua
@@ -20,10 +20,33 @@ local default_opts = {
 
 local opts
 
+-- store parsed mappings so that we can remove old ones on refresh events
+M._mappings = {}
+
 local set_mappings = function(m)
-    local mappings = m or {}
-    for target, suffix in pairs(mappings) do
+    -- first clean up any existing
+    for _, suffix in pairs(M._mappings) do
+        vim.keymap.del("n", opts.prefix .. suffix)
+    end
+    local has_which_key, which_key = pcall(require, "which-key")
+    if has_which_key then
+        local slated_mappings = {}
+        for _, suffix in pairs(M._mappings) do
+            slated_mappings[opts.prefix .. suffix] = "which_key_ignore"
+        end
+        which_key.register(slated_mappings)
+    end
+    -- then set the new ones
+    M._mappings = m or {}
+    for target, suffix in pairs(M._mappings) do
         vim.keymap.set("n", opts.prefix .. suffix, M.make_runner(target), { desc = target })
+    end
+    if has_which_key then
+        local mappings = {}
+        for target, suffix in pairs(M._mappings) do
+            mappings[opts.prefix .. suffix] = target
+        end
+        which_key.register(mappings)
     end
 end
 

--- a/lua/makemapper/init.lua
+++ b/lua/makemapper/init.lua
@@ -61,7 +61,7 @@ M.setup = function(o)
         pattern = "*",
         callback = function()
             set_mappings(require("makemapper.makefile").parse_mappings())
-        end
+        end,
     })
 end
 

--- a/lua/makemapper/init.lua
+++ b/lua/makemapper/init.lua
@@ -8,9 +8,9 @@ end
 local runner = term_nvim
 
 -- given a general strategy for running commands, curry in "make {target}"
-M.make_runner = function(target)
+M.make_runner = function(target, cwd)
     return function()
-        runner("make " .. target)
+        runner("cd " .. cwd .. "; make " .. target)
     end
 end
 
@@ -23,7 +23,7 @@ local opts
 -- store parsed mappings so that we can remove old ones on refresh events
 M._mappings = {}
 
-local set_mappings = function(m)
+local set_mappings = function(m, cwd)
     -- first clean up any existing
     for _, suffix in pairs(M._mappings) do
         vim.keymap.del("n", opts.prefix .. suffix)
@@ -39,7 +39,7 @@ local set_mappings = function(m)
     -- then set the new ones
     M._mappings = m or {}
     for target, suffix in pairs(M._mappings) do
-        vim.keymap.set("n", opts.prefix .. suffix, M.make_runner(target), { desc = target })
+        vim.keymap.set("n", opts.prefix .. suffix, M.make_runner(target, cwd), { desc = target })
     end
     if has_which_key then
         local mappings = {}

--- a/lua/makemapper/init.lua
+++ b/lua/makemapper/init.lua
@@ -30,7 +30,16 @@ end
 M.setup = function(o)
     opts = vim.tbl_deep_extend("force", {}, default_opts, o or {})
 
-    set_mappings(require("makemapper.makefile").parse_mappings())
+    local augroup = vim.api.nvim_create_augroup("Makemapper", {})
+
+    local autocmd = vim.api.nvim_create_autocmd
+    autocmd("BufEnter", {
+        group = augroup,
+        pattern = "*",
+        callback = function()
+            set_mappings(require("makemapper.makefile").parse_mappings())
+        end
+    })
 end
 
 return M

--- a/lua/makemapper/makefile.lua
+++ b/lua/makemapper/makefile.lua
@@ -38,19 +38,27 @@ M.find_makefile = function(path)
     -- sanitize buffer names like `oil:///foo`
     path = path or vim.api.nvim_buf_get_name(0):gsub("^[^/]*/+", "/")
     local cwd = vim.fn.getcwd() .. "/"
-    if path == "" then path = cwd end
+    if path == "" then
+        path = cwd
+    end
     -- if we've reached cwd, then no Makefile has been found
-    if path:sub(1, #cwd) ~= cwd then return nil end
+    if path:sub(1, #cwd) ~= cwd then
+        return nil
+    end
     local dir = path:gsub("/+[^/]*$", "")
     local candidate = dir .. "/Makefile"
-    if file_exists(candidate) then return candidate end
+    if file_exists(candidate) then
+        return candidate
+    end
     return M.find_makefile(dir)
 end
 
 -- load Makefile into a buffer and return the id,
 -- or nil if not found
 M.makefile_buffer = function(path)
-    if not path then return end
+    if not path then
+        return
+    end
     local lines = lines_from(path)
     if lines == nil then
         return
@@ -65,7 +73,9 @@ end
 
 M._parse_makefile = function()
     local makefile_path = M.find_makefile()
-    if not makefile_path then return {} end
+    if not makefile_path then
+        return {}
+    end
     local makefile = M.makefile_buffer(makefile_path)
     if not makefile then
         return {}
@@ -84,7 +94,9 @@ end
 -- assignments
 M.parse_mappings = function()
     local parsed, cwd = M._parse_makefile()
-    if not parsed.mappings then return {} end
+    if not parsed.mappings then
+        return {}
+    end
     return M._parse_makefile().mappings, cwd
 end
 

--- a/lua/makemapper/makefile.lua
+++ b/lua/makemapper/makefile.lua
@@ -41,6 +41,7 @@ end
 -- or nil if not found
 M.makefile_buffer = function()
     local makefile_path = M.find_makefile()
+    if not makefile_path then return end
     local lines = lines_from(makefile_path)
     if lines == nil then
         return
@@ -149,7 +150,5 @@ M.parse_buffer = function(bufnr)
 
     return ctx
 end
-
-P(M.makefile_buffer())
 
 return M

--- a/lua/makemapper/makefile.lua
+++ b/lua/makemapper/makefile.lua
@@ -14,12 +14,6 @@ local file_exists = function(file)
     return ok, err
 end
 
---- Check if a directory exists in this path
-local isdir = function(path)
-    -- "/" works on both Unix and Windows
-    return file_exists(path .. "/")
-end
-
 -- get all lines from a file, returns an empty
 -- list/table if the file does not exist
 local lines_from = function(file)

--- a/lua/makemapper/makefile.lua
+++ b/lua/makemapper/makefile.lua
@@ -29,6 +29,7 @@ end
 M.find_makefile = function(path)
     path = path or vim.api.nvim_buf_get_name(0)
     local cwd = vim.fn.getcwd()
+    if path == "" then path = cwd end
     -- if we've reached cwd, then no Makefile has been found
     if path:sub(1, #cwd) ~= cwd then return nil end
     local dir = path:gsub("/[^/]*$", "")

--- a/lua/makemapper/makefile.lua
+++ b/lua/makemapper/makefile.lua
@@ -29,7 +29,7 @@ end
 M.find_makefile = function(path)
     path = path or vim.api.nvim_buf_get_name(0)
     local cwd = vim.fn.getcwd()
-    if path == "" then path = cwd end
+    if path == "" then path = cwd .. "/" end
     -- if we've reached cwd, then no Makefile has been found
     if path:sub(1, #cwd) ~= cwd then return nil end
     local dir = path:gsub("/[^/]*$", "")


### PR DESCRIPTION
When we have `Makefile`s in subdirectories, use the closest parent `Makefile` to the current buffer.

TODO:
- [x] clean up previous mappings on `BufEnter`
- [x] find new mappings on `BufEnter`
- [x] set correct `cwd` when executing `make`
